### PR TITLE
Delete compile.sh

### DIFF
--- a/compile.sh
+++ b/compile.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-javac -d ./classes ./src/*.java ./src/nlp/*.java ./src/database/*.java ./src/datagathering/*.java ./src/gui/*.java ./src/ai/*.java


### PR DESCRIPTION
Unnecessary script - if someone really wants to just compile, they can take the line from run.sh